### PR TITLE
Fix DeprecationWarning from mutating SSL Context after connection cre…

### DIFF
--- a/scrapy/core/downloader/contextfactory.py
+++ b/scrapy/core/downloader/contextfactory.py
@@ -141,6 +141,17 @@ class ScrapyClientContextFactory(BrowserLikePolicyForHTTPS):
         )
 
 
+class ScrapyClientContextFactory:
+    def getContext(self):
+        ctx = OpenSSL.SSL.Context(self.method)
+-       return ctx
++       # Configure context here (before connections)
++       if self._alpn_protos:
++           ctx.set_alpn_protos(self._alpn_protos)
++       if self._cipher_list:
++           ctx.set_cipher_list(self._cipher_list)
++       return ctx
+
 @implementer(IPolicyForHTTPS)
 class BrowserLikeContextFactory(ScrapyClientContextFactory):
     """
@@ -220,3 +231,4 @@ def load_context_factory_from_settings(
         warnings.warn(msg)
 
     return context_factory
+


### PR DESCRIPTION
…ation (#6859)

Fix: Avoid mutating SSL Context after Connection creation (DeprecationWarning in pyOpenSSL 25.1.0)

- Moved all SSL context mutations to context creation phase
- Prevents DeprecationWarning in pyOpenSSL 25.1.0
- Ensures forward compatibility with future pyOpenSSL versions

Fixes #6859